### PR TITLE
Add "infra" module sub-dir "//" back to main.tf

### DIFF
--- a/adk/llama/vllm/terraform/main.tf
+++ b/adk/llama/vllm/terraform/main.tf
@@ -59,7 +59,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   count  = var.create_cluster ? 1 : 0
 
   project_id        = var.project_id


### PR DESCRIPTION
Submodule separation character was removed in https://github.com/ai-on-gke/tutorials-and-examples/pull/32. This is causing module source pull to fail.