### PR TITLE
add double slash to gke sources

### DIFF
--- a/adk/vertex/terraform/main.tf
+++ b/adk/vertex/terraform/main.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 module "gke_cluster" {
-  source            = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source            = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   project_id        = var.project_id
   cluster_name      = local.cluster_name
   cluster_location  = var.cluster_location

--- a/flyte/main.tf
+++ b/flyte/main.tf
@@ -58,7 +58,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   count  = var.create_cluster ? 1 : 0
 
   project_id                = var.project_id

--- a/hugging-face-tgi/main.tf
+++ b/hugging-face-tgi/main.tf
@@ -53,13 +53,13 @@ provider "helm" {
 }
 
 module "namespace" {
-  source           = "github.com/ai-on-gke/common-infra/common/modules/kubernetes-namespace?ref=main"
+  source           = "github.com/ai-on-gke/common-infra//common/modules/kubernetes-namespace?ref=main"
   create_namespace = true
   namespace        = var.namespace
 }
 
 module "inference-server" {
-  source            = "github.com/ai-on-gke/common-infra/common/modules/inference-service?ref=main"
+  source            = "github.com/ai-on-gke/common-infra//common/modules/inference-service?ref=main"
   namespace         = var.namespace
   additional_labels = var.additional_labels
   autopilot_cluster = var.autopilot_cluster

--- a/langchain-chatbot/terraform/iap.tf
+++ b/langchain-chatbot/terraform/iap.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "iap_auth" {
-  source = "github.com/ai-on-gke/common-infra/common/modules/iap?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/modules/iap?ref=main"
 
   project_id               = var.project_id
   namespace                = var.k8s_namespace

--- a/llamaindex/rag/terraform/main.tf
+++ b/llamaindex/rag/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "gke_cluster" {
-  source = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
 
   project_id        = var.project_id
   cluster_name      = local.cluster_name

--- a/metaflow/terraform/main.tf
+++ b/metaflow/terraform/main.tf
@@ -65,7 +65,7 @@ module "project-services" {
 }
 
 module "gke_cluster" {
-  source            = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source            = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   project_id        = var.project_id
   cluster_name      = local.cluster_name
   cluster_location  = var.cluster_location
@@ -135,4 +135,3 @@ provider "kubectl" {
     }
   }
 }
-

--- a/metaflow/terraform/network.tf
+++ b/metaflow/terraform/network.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "custom_network" {
-  source       = "github.com/ai-on-gke/common-infra/common/modules/gcp-network"
+  source       = "github.com/ai-on-gke/common-infra//common/modules/gcp-network"
   project_id   = var.project_id
   network_name = local.network_name
   create_psa   = true
@@ -33,5 +33,3 @@ module "custom_network" {
     }
   ]
 }
-
-

--- a/mlflow/finetune-gemma/terraform-gke-cluster/main.tf
+++ b/mlflow/finetune-gemma/terraform-gke-cluster/main.tf
@@ -58,7 +58,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   count  = var.create_cluster ? 1 : 0
 
   project_id        = var.project_id

--- a/ray-serve/terraform/main.tf
+++ b/ray-serve/terraform/main.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 module "gke_cluster" {
-  source            = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source            = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   project_id        = var.project_id
   cluster_name      = local.cluster_name
   cluster_location  = var.cluster_location

--- a/ray-serve/terraform/network.tf
+++ b/ray-serve/terraform/network.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "custom_network" {
-  source       = "github.com/ai-on-gke/common-infra/common/modules/gcp-network"
+  source       = "github.com/ai-on-gke/common-infra//common/modules/gcp-network"
   project_id   = var.project_id
   network_name = local.network_name
   create_psa   = true

--- a/skypilot-dws-kueue/main.tf
+++ b/skypilot-dws-kueue/main.tf
@@ -58,7 +58,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "github.com/ai-on-gke/common-infra/common/infrastructure?ref=main"
+  source = "github.com/ai-on-gke/common-infra//common/infrastructure?ref=main"
   count  = var.create_cluster ? 1 : 0
 
   project_id         = var.project_id
@@ -102,7 +102,7 @@ locals {
 }
 
 module "gcs" {
-  source      = "github.com/ai-on-gke/common-infra/common/modules/gcs?ref=main"
+  source      = "github.com/ai-on-gke/common-infra//common/modules/gcs?ref=main"
   count       = var.create_gcs_bucket ? 1 : 0
   project_id  = var.project_id
   bucket_name = var.gcs_bucket

--- a/workflow-orchestration/multikueue-dws/tf/versions.tf
+++ b/workflow-orchestration/multikueue-dws/tf/versions.tf
@@ -18,5 +18,17 @@ terraform {
       source = "hashicorp/google"
     }
 
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+}
+
+resource "google_storage_bucket" "random_bucket" {
+  name     = "random-bucket-${random_string.bucket_suffix.result}"
+  location = "US"
+
+  uniform_access_prevention = false
+}
+
   }
 }

--- a/workflow-orchestration/multikueue-dws/tf/versions.tf
+++ b/workflow-orchestration/multikueue-dws/tf/versions.tf
@@ -17,18 +17,5 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
-
-resource "random_string" "bucket_suffix" {
-  length  = 8
-  special = false
-}
-
-resource "google_storage_bucket" "random_bucket" {
-  name     = "random-bucket-${random_string.bucket_suffix.result}"
-  location = "US"
-
-  uniform_access_prevention = false
-}
-
   }
 }


### PR DESCRIPTION
According to [this documentation](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories), we should add a double slash to the source paths. This solves the issue with older Terraform.