### PR TITLE
Add custom VertexAI permission for adk/vertex tutorial

### DIFF
--- a/adk/vertex/terraform/default_env.tfvars
+++ b/adk/vertex/terraform/default_env.tfvars
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id            = "akvelon-gke-aieco"
+project_id            = "<PROJECT_ID>"
 default_resource_name = "adk-tf"
 
 cluster_name      = "" # Leave empty to use the default name (default_resource_name) 
@@ -25,7 +25,7 @@ subnetwork_name   = "" # Leave empty to use the default name
 subnetwork_region = "us-central1"
 subnetwork_cidr   = "10.128.0.0/20"
 
-kubernetes_namespace     = "default"
+kubernetes_namespace = "default"
 
 image_repository_name = ""
 

--- a/adk/vertex/terraform/workload_identity.tf
+++ b/adk/vertex/terraform/workload_identity.tf
@@ -17,6 +17,14 @@ locals {
   k8s_service_account_name = var.k8s_service_account_name != "" ? var.k8s_service_account_name : var.default_resource_name
 }
 
+resource "google_project_iam_custom_role" "vertexai_custom_role" {
+  project = var.project_id
+  role_id = "tutorialVertexAICustomRole"
+  title   = "VertexAI Tutorial Custom Role"
+  permissions = [
+    "aiplatform.endpoints.predict"
+  ]
+}
 
 module "aiplatform_workload_identity" {
   providers = {
@@ -27,9 +35,9 @@ module "aiplatform_workload_identity" {
   k8s_sa_name                     = local.k8s_service_account_name
   automount_service_account_token = true
   namespace                       = var.kubernetes_namespace
-  roles                           = [
-                                      "roles/aiplatform.user",
-                                    ]
-  project_id                      = var.project_id
-  depends_on                      = [module.gke_cluster]
+  roles = [
+    "projects/${var.project_id}/roles/tutorialVertexAICustomRole",
+  ]
+  project_id = var.project_id
+  depends_on = [module.gke_cluster]
 }


### PR DESCRIPTION
This PR introduces this [recommendation](https://cloud.google.com/vertex-ai/docs/general/access-control#least-privilege) in order to limit required VertexAI permissions

Related website changes: https://github.com/ai-on-gke/website/pull/175