### PR TITLE
Fix flowise cloudsql module dependencies

### DIFF
--- a/flowise/terraform/cloudsql.tf
+++ b/flowise/terraform/cloudsql.tf
@@ -63,6 +63,7 @@ module "cloudsql" {
       collation = "en_US.UTF8"
     },
   ]
+  depends_on = [module.custom_network]
 }
 
 resource "kubernetes_secret" "secret" {


### PR DESCRIPTION
This PR adds network module as a dependency to the cloudsql module. Without that, the cloudsql instance may start to be created with unfinished VPC.