### PR TITLE
Harden GitHub Actions workflows per zizmor findings

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -16,7 +16,11 @@
 # This workflow utilizes https://github.com/actions/github-script in GitHub Actions to apply labels to pull requests.
 #
 name: Label PR
-on: [pull_request_target]
+# pull_request_target is required so the bot can label PRs from forks, but no
+# PR code is ever checked out and the untrusted PR body is only read as a
+# string for a regex match, never executed or interpolated into a shell
+# command.
+on: [pull_request_target] # zizmor: ignore[dangerous-triggers]
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -25,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |-
             const keywords = {

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -29,7 +29,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30


### PR DESCRIPTION
## Summary

A [zizmor](https://docs.zizmor.sh/) security scan of this repository's GitHub Actions workflows flagged the following:

- **`unpinned-uses` (high, ×4)** — `actions/stale@v8` (in `close.yaml`, `obsolete.yaml`, `stale.yaml`) and `actions/github-script@v6` (in `label-pr.yaml`) were referenced by mutable version tag rather than a pinned commit SHA, which allows the upstream action's code to change without a corresponding change in this repo.
- **`dangerous-triggers` (high, confidence: medium)** — `label-pr.yaml` uses the `pull_request_target` trigger, which the audit flags because it's frequently combined with a checkout of untrusted PR code and thus commonly exploited.

## Changes

- Pinned `actions/stale` and `actions/github-script` to their resolved commit SHAs (with the human-readable version kept as a trailing comment).
- Reviewed and suppressed the `dangerous-triggers` finding on `label-pr.yaml` with an inline `zizmor: ignore` comment explaining the reasoning: the job never checks out PR code, and the untrusted PR body is only read as a plain string for a regex match — it's never executed or interpolated into a shell command — so the exploit pattern the audit assumes doesn't apply here. `pull_request_target` is required so the bot can label PRs opened from forks.

## Test plan

- [x] `zizmor` reports no findings against these workflows after the change (`No findings to report. Good job!`)
- [x] YAML validated as syntactically correct
- [ ] Confirm CI run on this PR passes with the pinned action versions
- [ ] Manually verify `label-pr.yaml` still labels a test PR correctly